### PR TITLE
add comments and more details for Julia package install

### DIFF
--- a/programs/packages.jl
+++ b/programs/packages.jl
@@ -1,11 +1,31 @@
-# from a suggestion at https://discourse.julialang.org/t/install-a-packages-from-a-list/30920/3
+###############################
+### create report quasi-package
 
 using Pkg
 
+# generate and activate the package for the submitted report
+Pkg.generate("path/to/reportpackage")
+Pkg.activate("path/to/reportpackage")
+
+# set of packages you want to install
 dependencies = [
     "IJulia",
-    "Genie"
+    "Genie",
+    "OnlineStats"
 ]
 
+# add these packages to the report's quasi-package
+# after this step there should be a Project.toml in "path/to/reportpackage" with the packages above
+# and a Manifest.toml in "path/to/reportpackage" with those packages' dependencies
 Pkg.add(dependencies)
+
+###############################
+### re-use of packages
+
+using Pkg
+
+# activate the report's quasi-package
+Pkg.activate("path/to/reportpackage")
+# instantiate: this will install any new dependencies in Manifest.toml and Project.toml
+Pkg.instantiate()
 


### PR DESCRIPTION
@larsvilhuber added some verbose comments and also included the path to the report's quasi/super/whatever package. Seems like it might be better to split the setup and the reuse into different parts and maybe that's what you meant earlier.